### PR TITLE
Amp executor

### DIFF
--- a/cmake/HPX_AddConfigTest.cmake
+++ b/cmake/HPX_AddConfigTest.cmake
@@ -76,6 +76,8 @@ macro(add_hpx_config_test variable)
           "-DCOMPILE_DEFINITIONS=${CONFIG_TEST_COMPILE_DEFINITIONS}"
         OUTPUT_VARIABLE ${variable}_OUTPUT
         COPY_FILE ${test_binary})
+       hpx_debug("Compile test: ${variable}")
+       hpx_debug("Compilation output: \n\n${${variable}_OUTPUT}") 
     endif()
 
     set(_run_msg "Success")
@@ -101,6 +103,7 @@ macro(add_hpx_config_test variable)
       hpx_add_config_define(${definition})
     endforeach()
   elseif(${variable}_REQUIRED)
+    hpx_warn("Test failed, detailed output:\n\n${${variable}_OUTPUT}")
     hpx_error(${${variable}_REQUIRED})
   endif()
 endmacro()

--- a/hpx/parallel/execution_policy.hpp
+++ b/hpx/parallel/execution_policy.hpp
@@ -1232,8 +1232,13 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
     struct gpu_task_execution_policy
     {
         /// The type of the executor associated with this execution policy
-		//typedef parallel::gpu_amp_executor executor_type;
+#if defined(HPX_WITH_AMP)
+		typedef parallel::gpu_amp_executor executor_type;
+#endif
+
+#if defined(HPX_WITH_SYCL)
 		typedef parallel::gpu_sycl_executor executor_type;
+#endif
 
         /// The category of the execution agents created by this execution
         /// policy.
@@ -1298,8 +1303,13 @@ namespace hpx { namespace parallel { HPX_INLINE_NAMESPACE(v1)
 	struct gpu_execution_policy
 	{
 		/// The type of the default executor associated with this execution policy
-		//typedef parallel::gpu_amp_executor executor_type;
+#if defined(HPX_WITH_AMP)
+		typedef parallel::gpu_amp_executor executor_type;
+#endif
+
+#if defined(HPX_WITH_SYCL)
 		typedef parallel::gpu_sycl_executor executor_type;
+#endif
 
 		/// The category of the execution agents created by this execution
 		/// policy.

--- a/src/util/coroutine/swapcontext64.ipp
+++ b/src/util/coroutine/swapcontext64.ipp
@@ -54,6 +54,12 @@
 #define HPX_COROUTINE_TYPE_DIRECTIVE(name) ".type " #name ", @function\n\t"
 #endif
 
+
+#if defined(__HCC_ACCELERATOR__)
+// disable inline assembly in case when HCC is building kernel codes
+#define HPX_COROUTINE_SWAPCONTEXT(name)
+
+#else
 // Note: .align 4 below means alignment at 2^4 boundary (16 bytes
 
 #define HPX_COROUTINE_SWAPCONTEXT(name)                                       \
@@ -87,6 +93,8 @@
         "jmp   *%rcx\n\t"                                                     \
         "ud2\n\t"                                                             \
     )                                                                         \
+
+#endif // #ifdef __HCC_ACCELERATOR__
 /**/
 
 HPX_COROUTINE_SWAPCONTEXT(swapcontext_stack);


### PR DESCRIPTION
Commits to make libhpx.so be built.

The crux of the issue is because libhpx contains GNU-style inline assembly codes, but HSAIL backend in HCC won't ignore them. So in this pull request we simply disable them in kernel compilation path.
